### PR TITLE
Improve performance of add_sos

### DIFF
--- a/docplex/mp/constants.py
+++ b/docplex/mp/constants.py
@@ -196,10 +196,6 @@ class SOSType(Enum):
         obj.cpx_sos_type = str(size)
         return obj
 
-
-    def lower(self):
-        return self.name.lower()
-
     @staticmethod
     def parse(arg,
               sos1_tokens=frozenset(['1', 'sos1']),

--- a/docplex/mp/constants.py
+++ b/docplex/mp/constants.py
@@ -189,6 +189,14 @@ class SOSType(Enum):
     """
     SOS1, SOS2 = 1, 2
 
+    def __new__(cls, size):
+        obj = object.__new__(cls)
+        # predefined
+        obj._value_ = size
+        obj.cpx_sos_type = str(size)
+        return obj
+
+
     def lower(self):
         return self.name.lower()
 
@@ -210,10 +218,6 @@ class SOSType(Enum):
                 return SOSType.SOS2
 
         docplex_fatal("Cannot convert to SOS type: {0!s} - expecting 1|2|'sos1'|'sos2'", arg)
-
-    def _cpx_sos_type(self):
-        # INTERNAL
-        return str(self.value)
 
     @property
     def size(self):

--- a/docplex/mp/cplex_adapter.py
+++ b/docplex/mp/cplex_adapter.py
@@ -93,6 +93,7 @@ class CplexAdapter(object):
         self.getlb = cpxproc.getlb
         self.getub = cpxproc.getub
         self.getsense = cpxproc.getsense
+        self.addsos = cpxproc.addsos
 
         # allocators
         try:

--- a/docplex/mp/cplex_engine.py
+++ b/docplex/mp/cplex_engine.py
@@ -1802,7 +1802,7 @@ class CplexEngine(IEngine):
         # procedural version
         cpx = self._cplex
         cpx_sos_type = sos_set.sos_type._cpx_sos_type()
-        indices = [dv.safe_index for dv in sos_set.iter_variables()]
+        indices = [dv._index for dv in sos_set.iter_variables()]
         weights = sos_set.weights
         # do NOT pass None to cplex/swig here --> crash
         cpx_sos_name = sos_set.safe_name

--- a/docplex/mp/cplex_engine.py
+++ b/docplex/mp/cplex_engine.py
@@ -1802,11 +1802,13 @@ class CplexEngine(IEngine):
         # procedural version
         cpx = self._cplex
         cpx_sos_type = sos_set.sos_type.cpx_sos_type
+        # sadly pycplex won't accept a tyuple here
         indices = [dv._index for dv in sos_set.iter_variables()]
         weights = sos_set.weights
         # do NOT pass None to cplex/swig here --> crash
         cpx_sos_name = sos_set.safe_name
         numsos = self._model.number_of_sos
+        # sadly pycplex won't accept  tuples here
         self.cpx_adapter.addsos(cpx._env._e,
                                 cpx._lp, cpx_sos_type,
                                 [0],

--- a/docplex/mp/cplex_engine.py
+++ b/docplex/mp/cplex_engine.py
@@ -1804,7 +1804,7 @@ class CplexEngine(IEngine):
         cpx_sos_type = sos_set.sos_type.cpx_sos_type
         # sadly pycplex won't accept a tyuple here
         indices = [dv._index for dv in sos_set.iter_variables()]
-        weights = sos_set.weights
+        weights = sos_set.get_cplex_weights()
         # do NOT pass None to cplex/swig here --> crash
         cpx_sos_name = sos_set.safe_name
         numsos = self._model.number_of_sos

--- a/docplex/mp/cplex_engine.py
+++ b/docplex/mp/cplex_engine.py
@@ -1801,7 +1801,7 @@ class CplexEngine(IEngine):
     def fast_create_sos(self, sos_set):
         # procedural version
         cpx = self._cplex
-        cpx_sos_type = sos_set.sos_type._cpx_sos_type()
+        cpx_sos_type = sos_set.sos_type.cpx_sos_type
         indices = [dv._index for dv in sos_set.iter_variables()]
         weights = sos_set.weights
         # do NOT pass None to cplex/swig here --> crash

--- a/docplex/mp/model.py
+++ b/docplex/mp/model.py
@@ -6826,23 +6826,26 @@ class Model(object):
             The newly added SOS.
         '''
         sos_type = SOSType.parse(sos_arg)
-        msg = 'Model.add_%s() expects an ordered sequence (or iterator) of variables' % sos_type.lower()
+        msg = f"Model.add_%s({sos_type.lower()}) expects an ordered sequence (or iterator) of variables"
         self._checker.check_ordered_sequence(arg=dvars, caller=msg)
         var_seq = self._checker.typecheck_var_seq(dvars, caller="Model.add_sos")
 
         var_list = list(var_seq)  # we need len here.
         nb_vars = len(var_list)
-        if nb_vars < sos_type.size:
-            self.fatal("A {0:s} variable set must contain at least {1:d} variables, got: {2:d}",
-                       sos_type.name, sos_type.size, nb_vars)
-        elif nb_vars == sos_type.size:
-            self.warning("{0:s} variable is trivial, contains {1} variable(s): all variables set to 1",
-                       sos_type.name, sos_type.size)
+        if nb_vars <= sos_type.size:
+            if nb_vars < sos_type.size:
+                self.fatal("A {0:s} variable set must contain at least {1:d} variables, got: {2:d}",
+                           sos_type.name, sos_type.size, nb_vars)
+            else:
+                self.warning("{0:s} variable is trivial, contains {1} variable(s): all variables set to 1",
+                              sos_type.name, sos_type.size)
+
         if weights is None:
             lweights = weights
         else:
-            lweights = StaticTypeChecker.typecheck_optional_num_seq(self, weights, accept_none=True, expected_size=nb_vars,
+            checked_weights = StaticTypeChecker.typecheck_optional_num_seq(self, weights, accept_none=True, expected_size=nb_vars,
                                                                 caller='Model.add_sos')
+            lweights = [float(w) for w in checked_weights]
         return self._add_sos(dvars, sos_type, weights=lweights, name=name)
 
     def _add_sos(self, dvars, sos_type, weights=None, name=None):

--- a/docplex/mp/model.py
+++ b/docplex/mp/model.py
@@ -6826,7 +6826,7 @@ class Model(object):
             The newly added SOS.
         '''
         sos_type = SOSType.parse(sos_arg)
-        msg = f"Model.add_%s({sos_type.lower()}) expects an ordered sequence (or iterator) of variables"
+        msg = f"Model.add_sos{sos_type.value} expects an ordered sequence (or iterator) of variables"
         self._checker.check_ordered_sequence(arg=dvars, caller=msg)
         var_seq = self._checker.typecheck_var_seq(dvars, caller="Model.add_sos")
 

--- a/docplex/mp/model.py
+++ b/docplex/mp/model.py
@@ -6838,7 +6838,10 @@ class Model(object):
         elif nb_vars == sos_type.size:
             self.warning("{0:s} variable is trivial, contains {1} variable(s): all variables set to 1",
                        sos_type.name, sos_type.size)
-        lweights = StaticTypeChecker.typecheck_optional_num_seq(self, weights, accept_none=True, expected_size=nb_vars,
+        if weights is None:
+            lweights = weights
+        else:
+            lweights = StaticTypeChecker.typecheck_optional_num_seq(self, weights, accept_none=True, expected_size=nb_vars,
                                                                 caller='Model.add_sos')
         return self._add_sos(dvars, sos_type, weights=lweights, name=name)
 

--- a/docplex/mp/model.py
+++ b/docplex/mp/model.py
@@ -516,6 +516,13 @@ class Model(object):
                 print("* Error in model_build_hook: {0!s}".format(me))
 
         self._ctstatus_counter = 0
+        self._cached_sos_weights = {}
+
+    def _get_cached_sos_weights(self, size):
+        sos_weight_cache = self._cached_sos_weights
+        if size not in sos_weight_cache:
+            sos_weight_cache[size] = [(i+1) for i in range(size)]
+        return sos_weight_cache[size]
 
     def _new_ct_status_index(self):
         # INTERNAL

--- a/docplex/mp/model.py
+++ b/docplex/mp/model.py
@@ -1851,9 +1851,10 @@ class Model(object):
             for dv, nvt in zip(dvars, new_vartypes):
                 nlb, nub = self._compute_changed_var_bounds(dv, nvt)
                 newbounds_dict[dv] = nlb, nub
-                if sol and not nvt.accept_value(sol[dv]):
+                dvv = sol._get_var_value(dv) if sol else 0
+                if sol and not nvt.accept_value(dvv):
                     self.warning("Variable {0} has solution value {1} incompatible with new type {2}",
-                                 dv.name, sol[dv], nvt.short_name)
+                                 dv.name,dvv, nvt.short_name)
                     nb_incompatible_sol_values += 1
         except DOcplexException as vtex:
             # something went wrong in bounds change

--- a/docplex/mp/model.py
+++ b/docplex/mp/model.py
@@ -1829,8 +1829,17 @@ class Model(object):
             self._change_var_types_internal((dvar,), (new_vartype,))
         return dvar
 
-    def change_var_types(self, dvars, vartype_args, discard_incompatible_solution=False):
+    def change_var_types(self, dvars, vartype_args, discard_incompatible_solution=True):
+        """ Change  type for a collection of variables.
+        :param dvars: an iterable on decision variables.
+        :param vartype_args: either an iterable over variable types, or one single type.
+        :param discard_incompatible_solution: boolean (default is True).
+            If the model has a current solution, and if one of the changed variables
+            has a value in this solution, which is incompatible with the new type, the
+            the solution is discarded. For example, if a continuous variable with value 3.14
+            is changed to binary type, then the solution is discarded
 
+        """
         candidate_vars = dvars.values() if isinstance(dvars, dict) else dvars
         checked_vars = list(self._checker.typecheck_var_seq(candidate_vars, caller="Model.change_var_types"))
 

--- a/docplex/mp/model.py
+++ b/docplex/mp/model.py
@@ -6826,8 +6826,8 @@ class Model(object):
             The newly added SOS.
         '''
         sos_type = SOSType.parse(sos_arg)
-        msg = f"Model.add_sos{sos_type.value} expects an ordered sequence (or iterator) of variables"
-        self._checker.check_ordered_sequence(arg=dvars, caller=msg)
+        msgfn = lambda: f"Model.add_sos{sos_type.value} expects an ordered sequence (or iterator) of variables"
+        self._checker.check_ordered_sequence(arg=dvars, caller=msgfn)
         var_seq = self._checker.typecheck_var_seq(dvars, caller="Model.add_sos")
 
         var_list = list(var_seq)  # we need len here.

--- a/docplex/mp/solution.py
+++ b/docplex/mp/solution.py
@@ -531,7 +531,7 @@ class SolveSolution(object):
         """
         checker = self._checker
         checker.check_ordered_sequence(arg=dvars,
-                                       caller='SolveSolution.get_values() expects ordered sequence of variables')
+                                       caller='SolveSolution.get_values()')
         dvar_seq = checker.typecheck_var_seq(dvars)
         return self._get_values(dvar_seq)
 

--- a/docplex/mp/sosvarset.py
+++ b/docplex/mp/sosvarset.py
@@ -18,15 +18,6 @@ class SOSVariableSet(IndexableObject, _AbstractBendersAnnotated):
 
     __slots__ = ('_sos_type', '_variables', '_weights')
 
-    _default_weights_dir = {}
-
-    @classmethod
-    def _get_default_weights(cls, size):
-        if size not in cls._default_weights_dir:
-            def_weights = [1+i for i in range(size)]
-            cls._default_weights_dir[size] = def_weights
-        return cls._default_weights_dir[size]
-
     def __init__(self, model, variable_sequence, sos_type, weights=None, name=None):
         IndexableObject.__init__(self, model, name)
         self._sos_type = sos_type
@@ -109,7 +100,7 @@ class SOSVariableSet(IndexableObject, _AbstractBendersAnnotated):
     @property
     def weights(self):
         self_weights = self._weights
-        return self_weights if self_weights is not None else self._get_default_weights(self.size)
+        return self_weights if self_weights is not None else self._model._get_cached_sos_weights(self.size)
 
     @weights.setter
     def weights(self, new_weights):

--- a/docplex/mp/sosvarset.py
+++ b/docplex/mp/sosvarset.py
@@ -16,6 +16,8 @@ class SOSVariableSet(IndexableObject, _AbstractBendersAnnotated):
         and :func:`docplex.mp.model.Model.add_sos2` methods in Model.
     '''
 
+    __slots__ = ('_sos_type', '_variables', '_weights')
+
     def __init__(self, model, variable_sequence, sos_type, weights=None, name=None):
         IndexableObject.__init__(self, model, name)
         self._sos_type = sos_type

--- a/docplex/mp/sosvarset.py
+++ b/docplex/mp/sosvarset.py
@@ -22,6 +22,7 @@ class SOSVariableSet(IndexableObject, _AbstractBendersAnnotated):
         IndexableObject.__init__(self, model, name)
         self._sos_type = sos_type
         self._variables = variable_sequence[:]  # copy sequence
+        self._weights = None
         self._set_weights(weights)
 
     def _set_weights(self, new_weights):
@@ -107,7 +108,6 @@ class SOSVariableSet(IndexableObject, _AbstractBendersAnnotated):
         lhs = mdl.sum_vars(self._variables)
         rhs = lfactory.constant_expr(self.sos_type.value)
         return lfactory.new_binary_constraint(lhs, "le", rhs, name=self.name)
-
 
     def __str__(self):
         ''' Redefine the standard __str__ method of Python objects to customize string conversion.

--- a/docplex/mp/sosvarset.py
+++ b/docplex/mp/sosvarset.py
@@ -36,6 +36,21 @@ class SOSVariableSet(IndexableObject, _AbstractBendersAnnotated):
             if len(weight_list) != nb_vars:
                 self._model.fatal("Expecting {0} SOS weights, a list with size {1} was passed",
                                   nb_vars, len(weight_list))
+            # check weights are unique
+
+            def _find_duplicate(wlist_):
+                wset_ = set()
+                for w in wlist_:
+                    if w in wset_:
+                        return w
+                    else:
+                        wset_.add(w)
+                return None
+            setof_weights = set(weight_list)
+            if len(setof_weights) != nb_vars:
+                dupw = _find_duplicate(weight_list)
+                self._model.fatal("SOS weights must be unique, duplicate weight: {}", dupw)
+
             self._weights = weight_list[:]
 
     @property
@@ -99,12 +114,15 @@ class SOSVariableSet(IndexableObject, _AbstractBendersAnnotated):
 
     @property
     def weights(self):
+        return self.get_cplex_weights()
+
+    # @weights.setter
+    # def weights(self, new_weights):
+    #     self._set_weights(new_weights)
+
+    def get_cplex_weights(self):
         self_weights = self._weights
         return self_weights if self_weights is not None else self._model._get_cached_sos_weights(self.size)
-
-    @weights.setter
-    def weights(self, new_weights):
-        self._set_weights(new_weights)
 
     def as_constraint(self):
         mdl = self._model

--- a/docplex/mp/tck.py
+++ b/docplex/mp/tck.py
@@ -543,8 +543,9 @@ class StandardTypeChecker(DOcplexLoggerTypeChecker):
     def check_ordered_sequence(self, arg, caller, accept_iterator=True):
         # in some cases, we need an ordered sequence, if not the code won't crash
         # but may do unexpected things
+        s_caller = resolve_caller_as_string(caller)
         if not(is_ordered_sequence(arg) or (accept_iterator and is_iterator(arg))):
-            self.fatal("{0}, got: {1!s}", caller, type(arg).__name__)
+            self.fatal("{0}, got: {1!s}", s_caller, type(arg).__name__)
 
     def check_solution_hook(self, mdl, sol_hook_fn):
         if not callable(sol_hook_fn):

--- a/docplex/mp/tck.py
+++ b/docplex/mp/tck.py
@@ -545,7 +545,7 @@ class StandardTypeChecker(DOcplexLoggerTypeChecker):
         # but may do unexpected things
         s_caller = resolve_caller_as_string(caller)
         if not(is_ordered_sequence(arg) or (accept_iterator and is_iterator(arg))):
-            self.fatal("{0}, got: {1!s}", s_caller, type(arg).__name__)
+            self.fatal("{0}expects ordered sequence of variables, got: {1!s}", s_caller, type(arg).__name__)
 
     def check_solution_hook(self, mdl, sol_hook_fn):
         if not callable(sol_hook_fn):


### PR DESCRIPTION
Model.add_sos did not use the procedural API
cf https://stackoverflow.com/questions/76026076/why-add-sos1-method-of-docplex-is-taking-too-long

Now it runs 30% faster; bottleneck is on creating the int/float arrays before diving into Cplex.
Still there is a bottleneck in building int/float arrays before diving into Cplex.
It seems I don't have the Cplex/Python versions with Vincent's improvements?

In addition, The CPXXaddsos API requests a mandatory `weights` array which, 99% of the time is a dummy array with consecutive numbers; the CPLEX API should accept NULL for this and build this dummy array in C for itself, IMHO
