### PR TITLE
Fix errors with numpy2

### DIFF
--- a/docplex/cp/utils.py
+++ b/docplex/cp/utils.py
@@ -1658,7 +1658,6 @@ if IS_NUMPY_AVAILABLE:
     INTEGER_TYPES.add(numpy.uint32)
     INTEGER_TYPES.add(numpy.uint64)
 
-    FLOAT_TYPES.add(numpy.float_)
     FLOAT_TYPES.add(numpy.float16)
     FLOAT_TYPES.add(numpy.float32)
     FLOAT_TYPES.add(numpy.float64)

--- a/docplex/mp/utils.py
+++ b/docplex/mp/utils.py
@@ -57,7 +57,6 @@ try:
     __int_types.add(numpy.uint32)
     __float_types.add(numpy.uint64)
 
-    __float_types.add(numpy.float_)
     __float_types.add(numpy.float16)
     __float_types.add(numpy.float32)
     __float_types.add(numpy.float64)

--- a/docplex/util/environment.py
+++ b/docplex/util/environment.py
@@ -1089,7 +1089,7 @@ attachment_trans_table = maketrans(attachment_invalid_characters, '_' * len(atta
 
 
 def make_attachment_name(name):
-    '''From `name`, create an attachment name that is correct for DOcplexcloud.
+    r'''From `name`, create an attachment name that is correct for DOcplexcloud.
 
     Attachment filenames in DOcplexcloud has certain restrictions. A file name:
 


### PR DESCRIPTION
docplex raises an error with numpy 2.
This PR fixes them.

This PR also fixes an escape error of a docstring.

```python
try:
    from docplex.cp.model import CpoModel
except Exception as ex:
    print(ex)
try:
    from docplex.mp.model import Model
except Exception as ex:
    print(ex)
```

docplex 2.27.239
```
`np.float_` was removed in the NumPy 2.0 release. Use `np.float64` instead.
`np.float_` was removed in the NumPy 2.0 release. Use `np.float64` instead.
```

this PR
```
```