### PR TITLE
Fixed broken docsting syntax.

### DIFF
--- a/docplex/util/environment.py
+++ b/docplex/util/environment.py
@@ -1095,7 +1095,7 @@ def make_attachment_name(name):
 
         - is limited to 255 characters;
         - can include only ASCII characters;
-        - cannot include the characters `/\?%*:|"<>`, the space character, or the null character; and
+        - cannot include the characters `/\\?%*:|"<>`, the space character, or the null character; and
         - cannot include _ as the first character.
 
     This method replace all unauthorized characters with _, then removing leading


### PR DESCRIPTION
Python 3.12 has adjusted its string syntax support leading to `\?` raising a `SyntaxError`.
This small change resolves that.